### PR TITLE
No need to set the active span

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "open-telemetry/opentelemetry": "dev-master"
+    "open-telemetry/opentelemetry": "dev-use-noop-span"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,8 @@
   "description": "Laravel middleware to send events to OpenTelemetry",
   "type": "library",
   "license": "MIT",
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/beniamin/opentelemetry-php"
-    }
-  ],
   "require": {
-    "open-telemetry/opentelemetry": "dev-remove-global-span"
+    "open-telemetry/opentelemetry": "dev-master"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,14 @@
   "description": "Laravel middleware to send events to OpenTelemetry",
   "type": "library",
   "license": "MIT",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/beniamin/opentelemetry-php"
+    }
+  ],
   "require": {
-    "open-telemetry/opentelemetry": "dev-master"
+    "open-telemetry/opentelemetry": "dev-remove-global-span"
   },
   "autoload": {
     "psr-4": {

--- a/src/Middleware/OpenTelemetryRequests.php
+++ b/src/Middleware/OpenTelemetryRequests.php
@@ -24,7 +24,6 @@ class OpenTelemetryRequests
         $tracer = app('laravel-opentelemetry');
 
         $span = $tracer->startAndActivateSpan('http_request');
-        $tracer->setActiveSpan($span);
 
         $span->setAttribute('request.path', $request->path())
              ->setAttribute('request.url', $request->fullUrl())


### PR DESCRIPTION
The active span is set in the `startAndActivateSpan` method, so there's no need to set it again immediately afterwards.