### PR TITLE
ServiceProvider injects implementation of OpenTelemetry Tracer interface

### DIFF
--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -11,10 +11,10 @@ use OpenTelemetry\Sdk\Trace\TracerProvider;
 class LaravelOpenTelemetryServiceProvider extends ServiceProvider
 {
     /**
-    * Publishes configuration file.
-    *
-    * @return  void
-    */
+     * Publishes configuration file.
+     *
+     * @return void
+     */
     public function boot()
     {
         $this->publishes([
@@ -27,10 +27,10 @@ class LaravelOpenTelemetryServiceProvider extends ServiceProvider
         );
     }
     /**
-    * Make config publishment optional by merging the config from the package.
-    *
-    * @return  void
-    */
+     * Make config publishment optional by merging the config from the package.
+     *
+     * @return void
+     */
     public function register()
     {
         // I think I'd prefer to use Type Hinting for accessing this OpenTelemetry instance
@@ -43,7 +43,6 @@ class LaravelOpenTelemetryServiceProvider extends ServiceProvider
 
     private function initOpenTelemetry()
     {
-
         if (config('laravel_opentelemetry.enable')) {
             $zipkinExporter = new ZipkinExporter(
                 config('laravel_opentelemetry.service_name'),

--- a/src/LaravelOpenTelemetryServiceProvider.php
+++ b/src/LaravelOpenTelemetryServiceProvider.php
@@ -43,7 +43,6 @@ class LaravelOpenTelemetryServiceProvider extends ServiceProvider
         });
     }
 
-
     /**
      * Initialize an OpenTelemetry Tracer with the exporter
      * specified in the application configuration.

--- a/src/Middleware/OpenTelemetryRequests.php
+++ b/src/Middleware/OpenTelemetryRequests.php
@@ -9,7 +9,7 @@ use OpenTelemetry\Trace\Tracer;
 class OpenTelemetryRequests
 {
     /**
-     * @var Tracer  $tracer  OpenTelemetry Tracer
+     * @var Tracer $tracer OpenTelemetry Tracer
      */
     private $tracer;
 

--- a/src/Middleware/OpenTelemetryRequests.php
+++ b/src/Middleware/OpenTelemetryRequests.php
@@ -4,10 +4,19 @@ namespace SeanHood\LaravelOpenTelemetry\Middleware;
 
 use Closure;
 
-use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace\Tracer;
 
 class OpenTelemetryRequests
 {
+    /**
+     * @var Tracer  $tracer  OpenTelemetry Tracer
+     */
+    private $tracer;
+
+    public function __construct(Tracer $tracer)
+    {
+        $this->tracer = $tracer;
+    }
 
     /**
      * Handle an incoming request.
@@ -18,13 +27,8 @@ class OpenTelemetryRequests
      */
     public function handle($request, Closure $next)
     {
-
-        // I'd prefer to use Type Hinting for accessing this OpenTelemetry instance
-        // How do I do that?
-        $tracer = app('laravel-opentelemetry');
-
-        $span = $tracer->startAndActivateSpan('http_request');
-        $tracer->setActiveSpan($span);
+        $span = $this->tracer->startAndActivateSpan('http_request');
+        $this->tracer->setActiveSpan($span);
 
         $span->setAttribute('request.path', $request->path())
              ->setAttribute('request.url', $request->fullUrl())
@@ -35,9 +39,8 @@ class OpenTelemetryRequests
 
         $response = $next($request);
 
-
         $span->setAttribute('response.status', $response->status());
-        $tracer->endActiveSpan();
+        $this->tracer->endActiveSpan();
 
         return $response;
     }

--- a/src/Middleware/OpenTelemetryRequests.php
+++ b/src/Middleware/OpenTelemetryRequests.php
@@ -28,7 +28,6 @@ class OpenTelemetryRequests
     public function handle($request, Closure $next)
     {
         $span = $this->tracer->startAndActivateSpan('http_request');
-        $this->tracer->setActiveSpan($span);
 
         $span->setAttribute('request.path', $request->path())
              ->setAttribute('request.url', $request->fullUrl())


### PR DESCRIPTION
Changes the `LaravelOpenTelemetryServiceProvider` to inject a concrete implementation of the OpenTelemetry `Tracer` interface, rather than injecting a arbitrary string. This allows us to use constructor DI, as well.

Also added some phpdoc comments.