### PR TITLE
Add Middleware Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ composer require seanhood/laravel-opentelemetry
 
 protected $middleware = [
     ...
-
-    \SeanHood\LaravelOpenTelemetry\Middleware\OpenTelemetryRequests::class
+    \SeanHood\LaravelOpenTelemetry\Middleware\Trace::class
 ];
 ```
 

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -6,7 +6,10 @@ use Closure;
 
 use OpenTelemetry\Trace\Tracer;
 
-class OpenTelemetryRequests
+/**
+ * Trace an incoming HTTP request
+ */
+class Trace
 {
     /**
      * @var Tracer $tracer OpenTelemetry Tracer
@@ -27,7 +30,7 @@ class OpenTelemetryRequests
      */
     public function handle($request, Closure $next)
     {
-        $span = $this->tracer->startAndActivateSpan('http_request');
+        $span = $this->tracer->startAndActivateSpan('http_'.$request->method());
 
         $span->setAttribute('request.path', $request->path())
              ->setAttribute('request.url', $request->fullUrl())

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -66,7 +66,7 @@ class Trace
             $span->setSpanStatus(SpanStatus::INTERNAL, SpanStatus::DESCRIPTION[SpanStatus::INTERNAL]);
         }
 
-        if($httpStatusCode >= 200 && $httpStatusCode <= 300) {
+        if($httpStatusCode >= 200 && $httpStatusCode < 300) {
             $span->setSpanStatus(SpanStatus::OK, SpanStatus::DESCRIPTION[SpanStatus::OK]);
         }
     }

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use OpenTelemetry\Trace\Span;
+use OpenTelemetry\Trace\SpanStatus;
 use OpenTelemetry\Trace\Tracer;
 
 /**
@@ -35,12 +36,39 @@ class Trace
         $span = $this->tracer->startAndActivateSpan('http_'.strtolower($request->method()));
         $response = $next($request);
 
+        $this->setSpanStatus($span, $response->status());
         $this->addConfiguredTags($span, $request, $response);
         $span->setAttribute('response.status', $response->status());
         
         $this->tracer->endActiveSpan();
 
         return $response;
+    }
+
+    private function setSpanStatus(Span $span, int $httpStatusCode)
+    {
+        switch($httpStatusCode) {
+            case 400:
+                $span->setSpanStatus(SpanStatus::FAILED_PRECONDITION, SpanStatus::DESCRIPTION[SpanStatus::FAILED_PRECONDITION]);
+                return;
+            case 401:
+                $span->setSpanStatus(SpanStatus::UNAUTHENTICATED, SpanStatus::DESCRIPTION[SpanStatus::UNAUTHENTICATED]);
+                return;
+            case 403:
+                $span->setSpanStatus(SpanStatus::PERMISSION_DENIED, SpanStatus::DESCRIPTION[SpanStatus::PERMISSION_DENIED]);
+                return;
+            case 404:
+                $span->setSpanStatus(SpanStatus::NOT_FOUND, SpanStatus::DESCRIPTION[SpanStatus::NOT_FOUND]);
+                return;
+        }
+
+        if($httpStatusCode >= 500 && $httpStatusCode < 600) {
+            $span->setSpanStatus(SpanStatus::INTERNAL, SpanStatus::DESCRIPTION[SpanStatus::INTERNAL]);
+        }
+
+        if($httpStatusCode >= 200 && $httpStatusCode <= 300) {
+            $span->setSpanStatus(SpanStatus::OK, SpanStatus::DESCRIPTION[SpanStatus::OK]);
+        }
     }
 
     private function addConfiguredTags(Span $span, Request $request, $response)

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -3,7 +3,8 @@
 namespace SeanHood\LaravelOpenTelemetry\Middleware;
 
 use Closure;
-
+use Illuminate\Http\Request;
+use OpenTelemetry\Trace\Span;
 use OpenTelemetry\Trace\Tracer;
 
 /**
@@ -45,5 +46,12 @@ class Trace
         $this->tracer->endActiveSpan();
 
         return $response;
+    }
+
+    private function tagUser(Request $request, Span $span)
+    {
+        if($request->user()) {
+            $span->setAttribute('request.user', $request->user()->email);
+        }
     }
 }

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -36,7 +36,6 @@ class Trace
         $response = $next($request);
 
         $this->addConfiguredTags($span, $request, $response);
-
         $span->setAttribute('response.status', $response->status());
         
         $this->tracer->endActiveSpan();
@@ -44,7 +43,7 @@ class Trace
         return $response;
     }
 
-    private function addConfiguredTags(Span $span, Request $request, Response $response)
+    private function addConfiguredTags(Span $span, Request $request, $response)
     {
         $configurationKey = 'laravel_opentelemetry.tags.';
 

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -40,10 +40,10 @@ class Trace
              ->setAttribute('request.ip', $request->ip())
              ->setAttribute('request.ua', $request->userAgent());
 
-        $this->tagUser($request, $span);
 
         $response = $next($request);
 
+        $this->tagUser($request, $span); // Has to be after request has been processed otherwise $request->user() is null
         $span->setAttribute('response.status', $response->status());
         $this->tracer->endActiveSpan();
 

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -40,6 +40,8 @@ class Trace
              ->setAttribute('request.ip', $request->ip())
              ->setAttribute('request.ua', $request->userAgent());
 
+        $this->tagUser($request, $span);
+
         $response = $next($request);
 
         $span->setAttribute('response.status', $response->status());

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -31,7 +31,7 @@ class Trace
      */
     public function handle($request, Closure $next)
     {
-        $span = $this->tracer->startAndActivateSpan('http_'.$request->method());
+        $span = $this->tracer->startAndActivateSpan('http_'.strtolower($request->method()));
 
         $span->setAttribute('request.path', $request->path())
              ->setAttribute('request.url', $request->fullUrl())

--- a/src/Middleware/Trace.php
+++ b/src/Middleware/Trace.php
@@ -40,7 +40,6 @@ class Trace
              ->setAttribute('request.ip', $request->ip())
              ->setAttribute('request.ua', $request->userAgent());
 
-
         $response = $next($request);
 
         $this->tagUser($request, $span); // Has to be after request has been processed otherwise $request->user() is null

--- a/src/config/laravel_opentelemetry.php
+++ b/src/config/laravel_opentelemetry.php
@@ -53,7 +53,7 @@ return [
     */
 
     'tags' => [
-        'ip'     => true, // Requestr's IP address
+        'ip'     => true, // Requester's IP address
         'path'   => true, // Path requested
         'url'    => true, // Full URL requested
         'method' => true, // HTTP method of the request

--- a/src/config/laravel_opentelemetry.php
+++ b/src/config/laravel_opentelemetry.php
@@ -1,7 +1,64 @@
 <?php
 
 return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable Tracing
+    |--------------------------------------------------------------------------
+    |
+    | This value determines whether or not requests are traced using OpenTelemetry
+    | instrumentation.
+    |
+    */
+
     'enable' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Service Name
+    |--------------------------------------------------------------------------
+    |
+    | This is the service name that is sent to your tracing infrastructure. If
+    | this is a system made up of multiple components (eg: a microservices
+    | architecture), then you should use a specific name that will tell you
+    | where in the system a request has been sent.
+    |
+    */
+
     'service_name' => 'laravel-otel',
-    'zipkin_endpoint' => 'http://localhost:9411/api/v2/spans'
+
+    /*
+    |--------------------------------------------------------------------------
+    | Zipkin Endpoint
+    |--------------------------------------------------------------------------
+    |
+    | This value is the URL of your Zipkin endpoint. Currently only exporting
+    | trace data in Zipkin format is supported. Make sure you include the
+    | protocol and port number.
+    |
+    */
+
+    'zipkin_endpoint' => 'http://localhost:9411/api/v2/spans',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tagging
+    |--------------------------------------------------------------------------
+    |
+    | The Trace middleware is able to enrich spans covering a HTTP request with
+    | metadata about the request. Using this array you can decide which metadata
+    | is included in your spans' tags.
+    |
+    */
+
+    'tags' => [
+        'ip'     => true, // Requestr's IP address
+        'path'   => true, // Path requested
+        'url'    => true, // Full URL requested
+        'method' => true, // HTTP method of the request
+        'secure' => true, // Whether the request has been secured with SSL/TLS
+        'ua'     => true, // Requester's user agent
+        'user'   => true, // Authenticated username
+    ]
 ];

--- a/src/config/laravel_opentelemetry.php
+++ b/src/config/laravel_opentelemetry.php
@@ -2,8 +2,6 @@
 
 return [
     'enable' => true,
-
-    'zipkin_endpoint' => 'http://localhost:9411/api/v2/spans',
-
-    'service_name' => 'laravel-otel'
+    'service_name' => 'laravel-otel',
+    'zipkin_endpoint' => 'http://localhost:9411/api/v2/spans'
 ];


### PR DESCRIPTION
Update the middleware:

- Use a verb as a name to match existing Laravel middleware
- Make the possible span tags configurable
- Add option to tag the authenticated user in the span
- Set the span status depending on the HTTP response code
- Document configuration options
- Include the HTTP verb in the span title / operation name